### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,9 @@
 name: PR Validation & Quality Gate
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/cfw4p/security/code-scanning/21](https://github.com/EchoCog/cfw4p/security/code-scanning/21)

To resolve this issue, you should explicitly set the `permissions` block at the top level of the workflow file. This will apply the minimum necessary permissions to all jobs unless overridden at the job level. In this case, the workflow requires `contents: read` (to check out code or for read-only repository access) and `issues: write` (to comment on issues and pull requests using the GitHub API). If comments are only ever posted to pull requests, you could use `pull-requests: write`, but because `github.rest.issues.createComment` is called, which works on both issues and pull requests, the more correct permission is `issues: write`. 

The most effective way to fix this is to add the following block immediately after the workflow `name` and before `on`:

```yaml
permissions:
  contents: read
  issues: write
```

No other changes to steps, jobs, or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
