### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,8 @@ jobs:
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/cfw4p/security/code-scanning/19](https://github.com/EchoCog/cfw4p/security/code-scanning/19)

To fix this issue, explicitly add a `permissions` block to the `Security Scanning` job. Since this job primarily involves reading the repository's `contents` and does not seem to require write access, the permissions can be set to `contents: read`. This ensures that the job adheres to the principle of least privilege, without affecting its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
